### PR TITLE
Add full config defaults

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,8 +8,19 @@ load_dotenv()  # read from .env at project root
 class Settings:
     """Application settings loaded from environment."""
     DATABASE_URL: str = os.getenv("DATABASE_URL")  # e.g. postgres://user:pass@host:port/dbname
-    # GARCH backtest defaults
-    DELTAS = [1, 5, 10]         # minute intervals to test
-    WINDOW_DAYS = [30, 60, 90]  # calibration windows in days
+    # Data grid
+    DELTAS_MIN = [1, 5, 10]       # aggregation intervals in minutes
+    WINDOW_DAYS = [30, 60, 90]    # calibration windows
+
+    # GARCH calibration
+    MLE_BOUNDS = [(1e-9, None), (0.0, 1.0), (0.0, 1.0)]  # ω>0, α≥0, β≥0
+    MLE_CONSTRAINT = lambda x: x[1] + x[2] < 1.0         # α+β <1
+    MLE_MAXITER = 10000
+
+    # Daily roll frequency
+    ROLL_FREQ = '1D'              # use pandas date_range with freq='1D'
+
+    # Backtest metrics
+    METRICS = ['mse', 'mae']
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- define backtest constants in `config.py`

## Testing
- `python -m py_compile config.py data_loader.py main.py`

------
https://chatgpt.com/codex/tasks/task_b_684eb30854b48333b56cd4d33b2ad6e6